### PR TITLE
Add MIDI file track selection

### DIFF
--- a/Assets/MidiAnim/Editor/MidiAnimImporter.cs
+++ b/Assets/MidiAnim/Editor/MidiAnimImporter.cs
@@ -12,6 +12,7 @@ namespace MidiAnim
     [ScriptedImporter(1, "midianim")]
     class MidiAnimImporter : ScriptedImporter
     {
+        [SerializeField] int _trackIndex = 0;
         [SerializeField] float _bpm = 120;
         [SerializeField] bool _gateEasing = false;
         [SerializeField] float _attackTime = 0.1f;
@@ -20,7 +21,7 @@ namespace MidiAnim
         public override void OnImportAsset(AssetImportContext context)
         {
             var song = MidiFileLoader.Load(File.ReadAllBytes(context.assetPath));
-            var seq = new MidiTrackSequencer(song.tracks[0], song.division, _bpm);
+            var seq = new MidiTrackSequencer(song.tracks[_trackIndex], song.division, _bpm);
 
             var clip = new MidiClip(_bpm);
             if (_gateEasing) clip.EnableEasing(_attackTime, _releaseTime);

--- a/Assets/MidiAnim/Editor/MidiAnimImporterEditor.cs
+++ b/Assets/MidiAnim/Editor/MidiAnimImporterEditor.cs
@@ -12,6 +12,7 @@ namespace MidiAnim
     [CustomEditor(typeof(MidiAnimImporter))]
     class MidiAnimImporterEditor : ScriptedImporterEditor
     {
+        SerializedProperty _trackIndex;
         SerializedProperty _bpm;
         SerializedProperty _gateEasing;
         SerializedProperty _attackTime;
@@ -19,6 +20,7 @@ namespace MidiAnim
 
         static class Styles
         {
+            public static readonly GUIContent TrackIndex = new GUIContent("Track Index");
             public static readonly GUIContent BPM = new GUIContent("BPM");
         }
 
@@ -29,6 +31,7 @@ namespace MidiAnim
         {
             base.OnEnable();
 
+            _trackIndex = serializedObject.FindProperty("_trackIndex");
             _bpm = serializedObject.FindProperty("_bpm");
             _gateEasing = serializedObject.FindProperty("_gateEasing");
             _attackTime = serializedObject.FindProperty("_attackTime");
@@ -37,6 +40,7 @@ namespace MidiAnim
 
         public override void OnInspectorGUI()
         {
+            EditorGUILayout.PropertyField(_trackIndex, Styles.TrackIndex);
             EditorGUILayout.PropertyField(_bpm, Styles.BPM);
             EditorGUILayout.PropertyField(_gateEasing);
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ There are a few settings in the inspector.
 
 ![inspector](https://i.imgur.com/HDWZgX7.png)
 
+- **Track Index** - The MIDI file track index that will be imported.
 - **BPM** - The importer doesn't support the BPM meta information, so that the
   BPM has to be set manually.
 - **Gate Easing** - When enabled, the note curves are to be smoothed by adding


### PR DESCRIPTION
My MIDI file is not importing correctly because it includes a few empty tracks. It's a common scenario for files exported from DAWs like Ableton or FL Studio.

I've added a GUI control allowing to select MIDI track. The default value is 0 like the hardcoded value was before my patch.

<img width="350" alt="screen shot 2018-05-22 at 19 01 47" src="https://user-images.githubusercontent.com/472392/40378003-9e3f52cc-5df2-11e8-9826-9c0fdf937948.png">
